### PR TITLE
Creación de archivos de requerimientos de pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,16 @@
+alembic==0.7.6
+aniso8601==1.0.0
+Flask==0.10.1
+Flask-Migrate==1.4.0
+Flask-RESTful==0.3.2
+Flask-Script==2.0.5
+Flask-SQLAlchemy==2.0
+itsdangerous==0.24
+Jinja2==2.7.3
+Mako==1.0.1
+MarkupSafe==0.23
+psycopg2==2.6
+pytz==2015.4
+six==1.9.0
+SQLAlchemy==1.0.4
+Werkzeug==0.10.4


### PR DESCRIPTION
Se creó el listado con todos los paquetes de Python instalados y requeridos por la aplicación.

Además del paquete **Flask**, son de destacar los paquetes **Flask-RESTful**, **Flask-SQLAlchemy** y **psycopg2**.