### PR TITLE
Creación inicial de shippable.yml

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -1,0 +1,7 @@
+language: python
+
+python:
+    - 2.7
+
+install:
+    - pip install -r requirements.txt


### PR DESCRIPTION
Se creó una versión inicial del archivo *shippable.yml*, que permite que el repositorio haga uso de **Shippable** como servidor de integración continua.