### PR TITLE
Configuración de servidor externamente visible

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,3 +1,4 @@
 #!flask/bin/python
 from app import app
-app.run(debug=True)
+
+app.run(host='0.0.0.0')


### PR DESCRIPTION
Se modificaron los parámetros de la aplicación Flask (en particular, el parámetro *host*), para permitir que sea accedida desde equipos de la red, y no sólo desde el servidor.

La documentación pertinente se encuentra en [Externally Visible Server - Flask Documentation](http://flask.pocoo.org/docs/0.10/quickstart/#public-server).