### PR TITLE
Incorporación de badge de requires.io al README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # salud-api
 
 [![Build Status](https://api.shippable.com/projects/5559677cedd7f2c052f196e0/badge?branchName=master)](https://app.shippable.com/projects/5559677cedd7f2c052f196e0/builds/latest)
+[![Requirements Status](https://requires.io/github/lightning-round/salud-api/requirements.svg?branch=master)](https://requires.io/github/lightning-round/salud-api/requirements/?branch=master)
 
 API Flask del asistente de salud personal


### PR DESCRIPTION
Se agregó al *README* el badge de **requires.io**, que muestra el estado de los requerimientos de la aplicación y si se encuentran actualizados.