### PR TITLE
Utilización de variable de entorno DATABASE_URL

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -5,7 +5,7 @@ class Config(object):
     TESTING = False
     CSRF_ENABLED = True
     SECRET_KEY = 'this-really-needs-to-be-changed'
-    SQLALCHEMY_DATABASE_URI = 'postgresql:///salud_dev?client_encoding=utf8'
+    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL', 'postgresql:///salud_dev?client_encoding=utf8')
 
 
 class ProductionConfig(Config):


### PR DESCRIPTION
Se hace uso de la variable de entorno **DATABASE_URL** para permitir la configuración de la base de datos desde Heroku, o personalizarla por parte del desarrollador.

En caso de no estar seteada en el equipo, se hace uso del valor por defecto, que es el segundo parámetro de ```os.environ.get```.