### PR TITLE
Actualización de Flask-RESTful a v0.3.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ alembic==0.7.6
 aniso8601==1.0.0
 Flask==0.10.1
 Flask-Migrate==1.4.0
-Flask-RESTful==0.3.2
+Flask-RESTful==0.3.3
 Flask-Script==2.0.5
 Flask-SQLAlchemy==2.0
 gunicorn==19.3.0


### PR DESCRIPTION
Se actualizó **Flask-RESTful** a la versión *0.3.3*. Según el [changelog](https://github.com/flask-restful/flask-restful/blob/master/CHANGES.md#version-033), no se modifica el comportamiento de las funciones utilizadas hasta el momento en el proyecto.