### PR TITLE
Especificación de argumentos obligatorios para solicitudes de API

### DIFF
--- a/app/mod_profiles/resources/measurementList.py
+++ b/app/mod_profiles/resources/measurementList.py
@@ -3,12 +3,12 @@ from app.mod_shared.models import db
 from app.mod_profiles.models import *
 
 parser = reqparse.RequestParser()
-parser.add_argument('datetime')
-parser.add_argument('value', type=float)
-parser.add_argument('profile_id', type=int)
+parser.add_argument('datetime', required=True)
+parser.add_argument('value', type=float, required=True)
+parser.add_argument('profile_id', type=int, required=True)
 parser.add_argument('measurement_source_id', type=int)
-parser.add_argument('measurement_type_id', type=int)
-parser.add_argument('measurement_unit_id', type=int)
+parser.add_argument('measurement_type_id', type=int, required=True)
+parser.add_argument('measurement_unit_id', type=int, required=True)
 
 resource_fields = {
     'datetime': fields.DateTime,

--- a/app/mod_profiles/resources/measurementSourceList.py
+++ b/app/mod_profiles/resources/measurementSourceList.py
@@ -3,7 +3,7 @@ from app.mod_shared.models import db
 from app.mod_profiles.models import *
 
 parser = reqparse.RequestParser()
-parser.add_argument('name', type=str)
+parser.add_argument('name', type=str, required=True)
 parser.add_argument('description', type=str)
 
 resource_fields = {

--- a/app/mod_profiles/resources/measurementSourceView.py
+++ b/app/mod_profiles/resources/measurementSourceView.py
@@ -3,7 +3,7 @@ from app.mod_shared.models import db
 from app.mod_profiles.models import *
 
 parser = reqparse.RequestParser()
-parser.add_argument('name', type=str)
+parser.add_argument('name', type=str, required=True)
 parser.add_argument('description', type=str)
 
 resource_fields = {

--- a/app/mod_profiles/resources/measurementTypeList.py
+++ b/app/mod_profiles/resources/measurementTypeList.py
@@ -3,7 +3,7 @@ from app.mod_shared.models import db
 from app.mod_profiles.models import *
 
 parser = reqparse.RequestParser()
-parser.add_argument('name', type=str)
+parser.add_argument('name', type=str, required=True)
 parser.add_argument('description', type=str)
 
 resource_fields = {

--- a/app/mod_profiles/resources/measurementTypeView.py
+++ b/app/mod_profiles/resources/measurementTypeView.py
@@ -3,7 +3,7 @@ from app.mod_shared.models import db
 from app.mod_profiles.models import *
 
 parser = reqparse.RequestParser()
-parser.add_argument('name', type=str)
+parser.add_argument('name', type=str, required=True)
 parser.add_argument('description', type=str)
 
 resource_fields = {

--- a/app/mod_profiles/resources/measurementUnitList.py
+++ b/app/mod_profiles/resources/measurementUnitList.py
@@ -3,8 +3,8 @@ from app.mod_shared.models import db
 from app.mod_profiles.models import *
 
 parser = reqparse.RequestParser()
-parser.add_argument('name', type=str)
-parser.add_argument('symbol', type=str)
+parser.add_argument('name', type=str, required=True)
+parser.add_argument('symbol', type=str, required=True)
 parser.add_argument('suffix', type=bool)
 
 resource_fields = {

--- a/app/mod_profiles/resources/measurementUnitView.py
+++ b/app/mod_profiles/resources/measurementUnitView.py
@@ -3,8 +3,8 @@ from app.mod_shared.models import db
 from app.mod_profiles.models import *
 
 parser = reqparse.RequestParser()
-parser.add_argument('name', type=str)
-parser.add_argument('symbol', type=str)
+parser.add_argument('name', type=str, required=True)
+parser.add_argument('symbol', type=str, required=True)
 parser.add_argument('suffix', type=bool)
 
 resource_fields = {

--- a/app/mod_profiles/resources/measurementView.py
+++ b/app/mod_profiles/resources/measurementView.py
@@ -3,12 +3,12 @@ from app.mod_shared.models import db
 from app.mod_profiles.models import *
 
 parser = reqparse.RequestParser()
-parser.add_argument('datetime')
-parser.add_argument('value', type=float)
-parser.add_argument('profile_id', type=int)
+parser.add_argument('datetime', required=True)
+parser.add_argument('value', type=float, required=True)
+parser.add_argument('profile_id', type=int, required=True)
 parser.add_argument('measurement_source_id', type=int)
-parser.add_argument('measurement_type_id', type=int)
-parser.add_argument('measurement_unit_id', type=int)
+parser.add_argument('measurement_type_id', type=int, required=True)
+parser.add_argument('measurement_unit_id', type=int, required=True)
 
 resource_fields = {
     'datetime': fields.DateTime,

--- a/app/mod_profiles/resources/profileList.py
+++ b/app/mod_profiles/resources/profileList.py
@@ -3,8 +3,8 @@ from app.mod_shared.models import db
 from app.mod_profiles.models import *
 
 parser = reqparse.RequestParser()
-parser.add_argument('last_name', type=str)
-parser.add_argument('first_name', type=str)
+parser.add_argument('last_name', type=str, required=True)
+parser.add_argument('first_name', type=str, required=True)
 parser.add_argument('gender', type=int)
 parser.add_argument('birthday')
 

--- a/app/mod_profiles/resources/profileView.py
+++ b/app/mod_profiles/resources/profileView.py
@@ -3,8 +3,8 @@ from app.mod_shared.models import db
 from app.mod_profiles.models import *
 
 parser = reqparse.RequestParser()
-parser.add_argument('last_name', type=str)
-parser.add_argument('first_name', type=str)
+parser.add_argument('last_name', type=str, required=True)
+parser.add_argument('first_name', type=str, required=True)
 parser.add_argument('gender', type=int)
 parser.add_argument('birthday')
 


### PR DESCRIPTION
Se explicitan los argumentos que son **obligatorios** para las solicitudes POST y PUT. Es importante aclarar que no todos los argumentos se han hecho obligatorios, sino sólo aquellos necesarios para el correcto funcionamiento de la aplicación.