### PR TITLE
Devolución de entidad creada en solicitud POST

### DIFF
--- a/app/mod_profiles/resources/measurementList.py
+++ b/app/mod_profiles/resources/measurementList.py
@@ -25,6 +25,7 @@ class MeasurementList(Resource):
         measurements = Measurement.query.all()
         return measurements
 
+    @marshal_with(resource_fields, envelope='resource')
     def post(self):
         args = parser.parse_args()
         new_measurement = Measurement(args['datetime'],
@@ -35,3 +36,4 @@ class MeasurementList(Resource):
                                       args['measurement_unit_id'])
         db.session.add(new_measurement)
         db.session.commit()
+        return new_measurement, 201

--- a/app/mod_profiles/resources/measurementSourceList.py
+++ b/app/mod_profiles/resources/measurementSourceList.py
@@ -17,9 +17,11 @@ class MeasurementSourceList(Resource):
         measurement_sources = MeasurementSource.query.all()
         return measurement_sources
 
+    @marshal_with(resource_fields, envelope='resource')
     def post(self):
         args = parser.parse_args()
         new_measurement_source = MeasurementSource(args['name'],
                                                    args['description'])
         db.session.add(new_measurement_source)
         db.session.commit()
+        return new_measurement_source, 201

--- a/app/mod_profiles/resources/measurementTypeList.py
+++ b/app/mod_profiles/resources/measurementTypeList.py
@@ -17,9 +17,11 @@ class MeasurementTypeList(Resource):
         measurement_types = MeasurementType.query.all()
         return measurement_types
 
+    @marshal_with(resource_fields, envelope='resource')
     def post(self):
         args = parser.parse_args()
         new_measurement_type = MeasurementType(args['name'],
                                                args['description'])
         db.session.add(new_measurement_type)
         db.session.commit()
+        return new_measurement_type, 201

--- a/app/mod_profiles/resources/measurementUnitList.py
+++ b/app/mod_profiles/resources/measurementUnitList.py
@@ -19,6 +19,7 @@ class MeasurementUnitList(Resource):
         measurement_units = MeasurementUnit.query.all()
         return measurement_units
 
+    @marshal_with(resource_fields, envelope='resource')
     def post(self):
         args = parser.parse_args()
         new_measurement_unit = MeasurementUnit(args['name'],
@@ -26,3 +27,4 @@ class MeasurementUnitList(Resource):
                                                args['suffix'])
         db.session.add(new_measurement_unit)
         db.session.commit()
+        return new_measurement_unit, 201

--- a/app/mod_profiles/resources/profileList.py
+++ b/app/mod_profiles/resources/profileList.py
@@ -21,6 +21,7 @@ class ProfileList(Resource):
         profiles = Profile.query.all()
         return profiles
 
+    @marshal_with(resource_fields, envelope='resource')
     def post(self):
         args = parser.parse_args()
         new_profile = Profile(args['last_name'],
@@ -29,4 +30,4 @@ class ProfileList(Resource):
                               args['birthday'])
         db.session.add(new_profile)
         db.session.commit()
-        pass
+        return new_profile, 201


### PR DESCRIPTION
Hasta el momento, las solicitudes POST **no retornaban ningún dato**, sólo un estado *HTTP 200* en caso de haberse ejecutado correctamente la solicitud.

Estos cambios proveen a las solicitudes POST la **devolución de la entidad creada**, junto con un estado *HTTP 201* (**Creado**).