### PR TITLE
Conversión de campos de fecha y hora a formato 'iso8601'

### DIFF
--- a/app/mod_profiles/resources/measurementView.py
+++ b/app/mod_profiles/resources/measurementView.py
@@ -11,7 +11,7 @@ parser.add_argument('measurement_type_id', type=int, required=True)
 parser.add_argument('measurement_unit_id', type=int, required=True)
 
 resource_fields = {
-    'datetime': fields.DateTime,
+    'datetime': fields.DateTime(dt_format='iso8601'),
     'value': fields.Float,
     'profile_id': fields.Integer,
     'measurement_source_id': fields.Integer,

--- a/app/mod_profiles/resources/profileView.py
+++ b/app/mod_profiles/resources/profileView.py
@@ -12,7 +12,7 @@ resource_fields = {
     'last_name': fields.String,
     'first_name': fields.String,
     'gender': fields.Integer,
-    'birthday': fields.DateTime,
+    'birthday': fields.DateTime(dt_format='iso8601'),
 }
 
 class ProfileView(Resource):


### PR DESCRIPTION
Por defecto, **Flask-RESTful** hace uso del formato **RFC 822** al recuperar los campos de fecha y hora y armar la respuesta JSON. Sin embargo, esto generaba un error *HTTP 500* (Internal Server Error) al querer recuperar cualquier objeto con un campo  de fecha y hora cargado.

En base a la [documentación del campo DateTime](https://flask-restful.readthedocs.org/en/latest/api.html#fields.DateTime), se resolvió al hacer uso del formato **ISO 8601** para los campos de fecha y hora.

Ejemplos de formatos:

* RFC 822

```Fri, 09 Nov 2001 01:08:47 -0000```

* ISO 8601

```2002-12-25 00:00:00-06:39```