### PR TITLE
Reutilización de 'resource fields' en recursos de listado

### DIFF
--- a/app/mod_profiles/resources/measurementList.py
+++ b/app/mod_profiles/resources/measurementList.py
@@ -1,6 +1,7 @@
-from flask_restful import Resource, reqparse, fields, marshal_with
+from flask_restful import Resource, reqparse, marshal_with
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
+from .measurementView import resource_fields
 
 parser = reqparse.RequestParser()
 parser.add_argument('datetime')
@@ -9,15 +10,6 @@ parser.add_argument('profile_id', type=int)
 parser.add_argument('measurement_source_id', type=int)
 parser.add_argument('measurement_type_id', type=int)
 parser.add_argument('measurement_unit_id', type=int)
-
-resource_fields = {
-    'datetime': fields.DateTime,
-    'value': fields.Float,
-    'profile_id': fields.Integer,
-    'measurement_source_id': fields.Integer,
-    'measurement_type_id': fields.Integer,
-    'measurement_unit_id': fields.Integer,
-}
 
 class MeasurementList(Resource):
     @marshal_with(resource_fields, envelope='resource')

--- a/app/mod_profiles/resources/measurementSourceList.py
+++ b/app/mod_profiles/resources/measurementSourceList.py
@@ -1,15 +1,11 @@
-from flask_restful import Resource, reqparse, fields, marshal_with
+from flask_restful import Resource, reqparse, marshal_with
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
+from .measurementSourceView import resource_fields
 
 parser = reqparse.RequestParser()
 parser.add_argument('name', type=str)
 parser.add_argument('description', type=str)
-
-resource_fields = {
-    'name': fields.String,
-    'description': fields.String,
-}
 
 class MeasurementSourceList(Resource):
     @marshal_with(resource_fields, envelope='resource')

--- a/app/mod_profiles/resources/measurementTypeList.py
+++ b/app/mod_profiles/resources/measurementTypeList.py
@@ -1,15 +1,11 @@
-from flask_restful import Resource, reqparse, fields, marshal_with
+from flask_restful import Resource, reqparse, marshal_with
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
+from .measurementTypeView import resource_fields
 
 parser = reqparse.RequestParser()
 parser.add_argument('name', type=str)
 parser.add_argument('description', type=str)
-
-resource_fields = {
-    'name': fields.String,
-    'description': fields.String,
-}
 
 class MeasurementTypeList(Resource):
     @marshal_with(resource_fields, envelope='resource')

--- a/app/mod_profiles/resources/measurementUnitList.py
+++ b/app/mod_profiles/resources/measurementUnitList.py
@@ -1,17 +1,12 @@
-from flask_restful import Resource, reqparse, fields, marshal_with
+from flask_restful import Resource, reqparse, marshal_with
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
+from .measurementUnitView import resource_fields
 
 parser = reqparse.RequestParser()
 parser.add_argument('name', type=str)
 parser.add_argument('symbol', type=str)
 parser.add_argument('suffix', type=bool)
-
-resource_fields = {
-    'name': fields.String,
-    'symbol': fields.String,
-    'suffix': fields.Boolean,
-}
 
 class MeasurementUnitList(Resource):
     @marshal_with(resource_fields, envelope='resource')


### PR DESCRIPTION
Hasta el momento, se repetía la definición de los campos de cada clase a ser devueltos en las respuestas de la API, tanto en el recurso **View** como **List** de la clase.

Estos cambios eliminan la redundancia, concentrando la definición de los **resource fields** en el recurso *View* de cada clase, y siendo reutilizado por el recurso *List* de la misma. 