### PR TITLE
Implementación de respuesta JSON de clase Measurement con relaciones

### DIFF
--- a/app/mod_profiles/resources/measurementView.py
+++ b/app/mod_profiles/resources/measurementView.py
@@ -1,6 +1,11 @@
 from flask_restful import Resource, reqparse, fields, marshal_with
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
+from .measurementSourceView import resource_fields as relation_measurement_source_fields
+from .measurementTypeView import resource_fields as relation_measurement_type_fields
+from .measurementUnitView import resource_fields as relation_measurement_unit_fields
+from .profileView import resource_fields as relation_profile_fields
+
 
 parser = reqparse.RequestParser()
 parser.add_argument('datetime', required=True)
@@ -13,10 +18,10 @@ parser.add_argument('measurement_unit_id', type=int, required=True)
 resource_fields = {
     'datetime': fields.DateTime(dt_format='iso8601'),
     'value': fields.Float,
-    'profile_id': fields.Integer,
-    'measurement_source_id': fields.Integer,
-    'measurement_type_id': fields.Integer,
-    'measurement_unit_id': fields.Integer,
+    'profile': fields.Nested(relation_profile_fields),
+    'measurement_source': fields.Nested(relation_measurement_source_fields),
+    'measurement_type': fields.Nested(relation_measurement_type_fields),
+    'measurement_unit': fields.Nested(relation_measurement_unit_fields),
 }
 
 class MeasurementView(Resource):


### PR DESCRIPTION
Estos cambios permiten que las solicitudes a recursos de la clase **Measurement** retornen un archivo JSON con la **información completa de sus relaciones**, y no sólo sus IDs.