### PR TITLE
Inclusión de campo ID en respuestas de la API

### DIFF
--- a/app/mod_profiles/resources/measurementSourceView.py
+++ b/app/mod_profiles/resources/measurementSourceView.py
@@ -7,6 +7,7 @@ parser.add_argument('name', type=str, required=True)
 parser.add_argument('description', type=str)
 
 resource_fields = {
+    'id': fields.Integer,
     'name': fields.String,
     'description': fields.String,
 }

--- a/app/mod_profiles/resources/measurementTypeView.py
+++ b/app/mod_profiles/resources/measurementTypeView.py
@@ -7,6 +7,7 @@ parser.add_argument('name', type=str, required=True)
 parser.add_argument('description', type=str)
 
 resource_fields = {
+    'id': fields.Integer,
     'name': fields.String,
     'description': fields.String,
 }

--- a/app/mod_profiles/resources/measurementUnitView.py
+++ b/app/mod_profiles/resources/measurementUnitView.py
@@ -8,6 +8,7 @@ parser.add_argument('symbol', type=str, required=True)
 parser.add_argument('suffix', type=bool)
 
 resource_fields = {
+    'id': fields.Integer,
     'name': fields.String,
     'symbol': fields.String,
     'suffix': fields.Boolean,

--- a/app/mod_profiles/resources/measurementView.py
+++ b/app/mod_profiles/resources/measurementView.py
@@ -16,6 +16,7 @@ parser.add_argument('measurement_type_id', type=int, required=True)
 parser.add_argument('measurement_unit_id', type=int, required=True)
 
 resource_fields = {
+    'id': fields.Integer,
     'datetime': fields.DateTime(dt_format='iso8601'),
     'value': fields.Float,
     'profile': fields.Nested(relation_profile_fields),

--- a/app/mod_profiles/resources/profileView.py
+++ b/app/mod_profiles/resources/profileView.py
@@ -9,6 +9,7 @@ parser.add_argument('gender', type=int)
 parser.add_argument('birthday')
 
 resource_fields = {
+    'id': fields.Integer,
     'last_name': fields.String,
     'first_name': fields.String,
     'gender': fields.Integer,


### PR DESCRIPTION
Estos cambios añaden el campo ```ID``` en toda respuesta JSON de la API. Esto permitirá que, al crear o modificar un objeto, el *frontend* reciba el ID del mismo para mostrar su página asociada.