### PR TITLE
Comprobación de argumentos para actualizaciones PUT

### DIFF
--- a/app/mod_profiles/resources/measurementSourceView.py
+++ b/app/mod_profiles/resources/measurementSourceView.py
@@ -22,7 +22,18 @@ class MeasurementSourceView(Resource):
     def put(self, id):
         measurement_source = MeasurementSource.query.get_or_404(id)
         args = parser.parse_args()
-        measurement_source.name(args['name'])
-        measurement_source.description(args['description'])
+
+        # Actualiza los atributos y relaciones del objeto, en base a los
+        # argumentos recibidos.
+
+        # Actualiza el nombre, en caso de que haya sido modificado.
+        if (args['name'] is not None and
+              measurement_source.name != args['name']):
+            measurement_source.name = args['name']
+        # Actualiza la descripcion, en caso de que haya sido modificada.
+        if (args['description'] is not None and
+              measurement_source.description != args['description']):
+            measurement_source.description = args['description']
+
         db.session.commit()
         return measurement_source, 200

--- a/app/mod_profiles/resources/measurementTypeView.py
+++ b/app/mod_profiles/resources/measurementTypeView.py
@@ -22,7 +22,18 @@ class MeasurementTypeView(Resource):
     def put(self, id):
         measurement_type = MeasurementType.query.get_or_404(id)
         args = parser.parse_args()
-        measurement_type.name(args['name'])
-        measurement_type.description(args['description'])
+
+        # Actualiza los atributos y relaciones del objeto, en base a los
+        # argumentos recibidos.
+
+        # Actualiza el nombre, en caso de que haya sido modificado.
+        if (args['name'] is not None and
+              measurement_type.name != args['name']):
+            measurement_type.name = args['name']
+        # Actualiza la descripcion, en caso de que haya sido modificada.
+        if (args['description'] is not None and
+              measurement_type.description != args['description']):
+            measurement_type.description = args['description']
+
         db.session.commit()
         return measurement_type, 200

--- a/app/mod_profiles/resources/measurementUnitView.py
+++ b/app/mod_profiles/resources/measurementUnitView.py
@@ -24,8 +24,23 @@ class MeasurementUnitView(Resource):
     def put(self, id):
         measurement_unit = MeasurementUnit.query.get_or_404(id)
         args = parser.parse_args()
-        measurement_unit.name(args['name'])
-        measurement_unit.symbol(args['symbol'])
-        measurement_unit.suffix(args['suffix'])
+
+        # Actualiza los atributos y relaciones del objeto, en base a los
+        # argumentos recibidos.
+
+        # Actualiza el nombre, en caso de que haya sido modificado.
+        if (args['name'] is not None and
+              measurement_unit.name != args['name']):
+            measurement_unit.name = args['name']
+        # Actualiza el simbolo de la unidad de medida, en caso de que haya sido
+        # modificado.
+        if (args['symbol'] is not None and
+              measurement_unit.symbol != args['symbol']):
+            measurement_unit.symbol = args['symbol']
+        # Actualiza el estado del sufijo, en caso de que haya sido modificado.
+        if (args['suffix'] is not None and
+              measurement_unit.suffix != args['suffix']):
+            measurement_unit.suffix = args['suffix']
+
         db.session.commit()
         return measurement_unit, 200

--- a/app/mod_profiles/resources/measurementView.py
+++ b/app/mod_profiles/resources/measurementView.py
@@ -35,11 +35,36 @@ class MeasurementView(Resource):
     def put(self, id):
         measurement = Measurement.query.get_or_404(id)
         args = parser.parse_args()
-        measurement.datetime(args['datetime'])
-        measurement.value(args['value'])
-        measurement.profile_id(args['profile_id'])
-        measurement.measurement_source_id(args['measurement_source_id'])
-        measurement.measurement_type_id(args['measurement_type_id'])
-        measurement.measurement_unit_id(args['measurement_unit_id'])
+
+        # Actualiza los atributos y relaciones del objeto, en base a los
+        # argumentos recibidos.
+
+        # Actualiza la fecha y hora, en caso de que haya sido modificada.
+        if (args['datetime'] is not None and
+              measurement.datetime != args['datetime']):
+            measurement.datetime = args['datetime']
+        # Actualiza el valor, en caso de que haya sido modificado.
+        if (args['value'] is not None and
+              measurement.value != args['value']):
+            measurement.value = args['value']
+        # Actualiza el perfil asociado, en caso de que haya sido modificado.
+        if (args['profile_id'] is not None and
+              measurement.profile_id != args['profile_id']):
+            measurement.profile_id = args['profile_id']
+        # Actualiza la fuente de la medicion, en caso de que haya sido
+        # modificada.
+        if (args['measurement_source_id'] is not None and
+              measurement.measurement_source_id != args['measurement_source_id']):
+            measurement.measurement_source_id = args['measurement_source_id']
+        # Actualiza el tipo de medicion, en caso de que haya sido modificado.
+        if (args['measurement_type_id'] is not None and
+              measurement.measurement_type_id != args['measurement_type_id']):
+            measurement.measurement_type_id = args['measurement_type_id']
+        # Actualiza la unidad de medida asociada, en caso de que haya sido
+        # modificada.
+        if (args['measurement_unit_id'] is not None and
+              measurement.measurement_unit_id != args['measurement_unit_id']):
+            measurement.measurement_unit_id = args['measurement_unit_id']
+
         db.session.commit()
         return measurement, 200

--- a/app/mod_profiles/resources/profileView.py
+++ b/app/mod_profiles/resources/profileView.py
@@ -26,9 +26,27 @@ class ProfileView(Resource):
     def put(self, id):
         profile = Profile.query.get_or_404(id)
         args = parser.parse_args()
-        profile.last_name(args['last_name'])
-        profile.first_name(args['first_name'])
-        profile.gender(args['gender'])
-        profile.birthday(args['birthday'])
+
+        # Actualiza los atributos y relaciones del objeto, en base a los
+        # argumentos recibidos.
+
+        # Actualiza el apellido, en caso de que haya sido modificado.
+        if (args['last_name'] is not None and
+              profile.last_name != args['last_name']):
+            profile.last_name = args['last_name']
+        # Actualiza el nombre, en caso de que haya sido modificado.
+        if (args['first_name'] is not None and
+              profile.first_name != args['first_name']):
+            profile.first_name = args['first_name']
+        # Actualiza el genero, en caso de que haya sido modificado.
+        if (args['gender'] is not None and
+              profile.gender != args['gender']):
+            profile.gender = args['gender']
+        # Actualiza la fecha de nacimiento, en caso de que haya sido
+        # modificada.
+        if (args['birthday'] is not None and
+              profile.birthday != args['birthday']):
+            profile.birthday = args['birthday']
+
         db.session.commit()
         return profile, 200


### PR DESCRIPTION
Estos cambios proveen una **validación** sencilla de los argumentos recibidos en una solicitud **PUT**. También considera que, en caso de no recibirse un argumento relacionado a un campo, éste no debe ser modificado. Así, la forma de vaciar un campo es mediante el **envío explícito del argumento con contenido vacío**.

Además, se corrigió la sintaxis de la actualización de campos, que no permitía el correcto funcionamiento de las solicitudes **PUT**.