### PR TITLE
Implementación de recurso API de las mediciones de un perfil

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -88,4 +88,6 @@ api.add_resource(MeasurementTypeList, '/measurement_types')
 api.add_resource(MeasurementUnitView, '/measurement_units/<int:id>')
 api.add_resource(MeasurementUnitList, '/measurement_units')
 
+api.add_resource(ProfileMeasurementList, '/profiles/<int:profile_id>/measurements')
+
 from app import views

--- a/app/mod_profiles/resources/__init__.py
+++ b/app/mod_profiles/resources/__init__.py
@@ -10,3 +10,5 @@ from measurementTypeView import MeasurementTypeView
 from measurementTypeList import MeasurementTypeList
 from measurementUnitView import MeasurementUnitView
 from measurementUnitList import MeasurementUnitList
+
+from .profileMeasurementList import ProfileMeasurementList

--- a/app/mod_profiles/resources/profileMeasurementList.py
+++ b/app/mod_profiles/resources/profileMeasurementList.py
@@ -1,0 +1,16 @@
+from flask_restful import Resource, marshal_with
+from app.mod_shared.models import db
+from app.mod_profiles.models import *
+from .measurementView import resource_fields as measurement_fields
+
+# Crea una copia de los campos del recurso 'Measurement'.
+resource_fields = measurement_fields.copy()
+# Quita el perfil asociado de los campos del recurso.
+del resource_fields['profile']
+
+class ProfileMeasurementList(Resource):
+    @marshal_with(resource_fields, envelope='resource')
+    def get(self, profile_id):
+        profile = Profile.query.get_or_404(profile_id)
+        measurements = profile.measurements.all()
+        return measurements


### PR DESCRIPTION
Se implementó un recurso, accesible desde ```/profiles/<profile_id>/measurements``` mediante **GET**, que retorna todas las mediciones asociadas al perfil especificado.