### PR TITLE
Implementación de recurso API de las últimas mediciones de un perfil

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -88,6 +88,7 @@ api.add_resource(MeasurementTypeList, '/measurement_types')
 api.add_resource(MeasurementUnitView, '/measurement_units/<int:id>')
 api.add_resource(MeasurementUnitList, '/measurement_units')
 
+api.add_resource(ProfileLatestMeasurementList, '/profiles/<int:profile_id>/measurements/latest')
 api.add_resource(ProfileMeasurementList, '/profiles/<int:profile_id>/measurements')
 
 from app import views

--- a/app/mod_profiles/resources/__init__.py
+++ b/app/mod_profiles/resources/__init__.py
@@ -11,4 +11,5 @@ from measurementTypeList import MeasurementTypeList
 from measurementUnitView import MeasurementUnitView
 from measurementUnitList import MeasurementUnitList
 
+from .profileLatestMeasurementList import ProfileLatestMeasurementList
 from .profileMeasurementList import ProfileMeasurementList

--- a/app/mod_profiles/resources/profileLatestMeasurementList.py
+++ b/app/mod_profiles/resources/profileLatestMeasurementList.py
@@ -1,0 +1,29 @@
+from flask_restful import Resource, marshal_with
+from app.mod_shared.models import db
+from app.mod_profiles.models import *
+from .measurementView import resource_fields as measurement_fields
+
+# Crea una copia de los campos del recurso 'Measurement'.
+resource_fields = measurement_fields.copy()
+# Quita el perfil asociado de los campos del recurso.
+del resource_fields['profile']
+
+class ProfileLatestMeasurementList(Resource):
+    @marshal_with(resource_fields, envelope='resource')
+    def get(self, profile_id):
+        measurement_types = MeasurementType.query.all()
+        profile = Profile.query.get_or_404(profile_id)
+        measurements = profile.measurements
+        latest_measurements = []
+
+        for measurement_type in measurement_types:
+            latest_from_type = None
+            corresponding_measurements = measurements.filter_by(measurement_type_id = measurement_type.id)
+            for measurement in corresponding_measurements:
+                if (not latest_from_type or
+                      measurement.datetime > latest_from_type.datetime):
+                    latest_from_type = measurement
+            if (latest_from_type):
+                latest_measurements.append(latest_from_type)
+
+        return latest_measurements


### PR DESCRIPTION
Se implementó un recurso, accesible desde ```/profiles/<profile_id>/measurements/latest``` mediante **GET**, que retorna las **últimas** mediciones asociadas al perfil especificado.

La respuesta incluye la **última medición de cada tipo de medición**, asociada al perfil.