### PR TITLE
Incorporación de atributo 'resource_field' dentro de clases

### DIFF
--- a/app/mod_profiles/resources/genderList.py
+++ b/app/mod_profiles/resources/genderList.py
@@ -1,19 +1,19 @@
 from flask_restful import Resource, reqparse, marshal_with
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
-from .genderView import resource_fields
+from .genderView import GenderView
 
 parser = reqparse.RequestParser()
 parser.add_argument('name', type=str, required=True)
 parser.add_argument('description', type=str)
 
 class GenderList(Resource):
-    @marshal_with(resource_fields, envelope='resource')
+    @marshal_with(GenderView.resource_fields, envelope='resource')
     def get(self):
         genders = Gender.query.all()
         return genders
 
-    @marshal_with(resource_fields, envelope='resource')
+    @marshal_with(GenderView.resource_fields, envelope='resource')
     def post(self):
         args = parser.parse_args()
         new_gender = Gender(args['name'],

--- a/app/mod_profiles/resources/genderView.py
+++ b/app/mod_profiles/resources/genderView.py
@@ -6,13 +6,13 @@ parser = reqparse.RequestParser()
 parser.add_argument('name', type=str, required=True)
 parser.add_argument('description', type=str)
 
-resource_fields = {
-    'id': fields.Integer,
-    'name': fields.String,
-    'description': fields.String,
-}
-
 class GenderView(Resource):
+    resource_fields = {
+        'id': fields.Integer,
+        'name': fields.String,
+        'description': fields.String,
+    }
+
     @marshal_with(resource_fields, envelope='resource')
     def get(self, id):
         gender = Gender.query.get_or_404(id)

--- a/app/mod_profiles/resources/measurementList.py
+++ b/app/mod_profiles/resources/measurementList.py
@@ -1,7 +1,7 @@
 from flask_restful import Resource, reqparse, marshal_with
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
-from .measurementView import resource_fields
+from .measurementView import MeasurementView
 
 parser = reqparse.RequestParser()
 parser.add_argument('datetime', required=True)
@@ -12,12 +12,12 @@ parser.add_argument('measurement_type_id', type=int, required=True)
 parser.add_argument('measurement_unit_id', type=int, required=True)
 
 class MeasurementList(Resource):
-    @marshal_with(resource_fields, envelope='resource')
+    @marshal_with(MeasurementView.resource_fields, envelope='resource')
     def get(self):
         measurements = Measurement.query.all()
         return measurements
 
-    @marshal_with(resource_fields, envelope='resource')
+    @marshal_with(MeasurementView.resource_fields, envelope='resource')
     def post(self):
         args = parser.parse_args()
         new_measurement = Measurement(args['datetime'],

--- a/app/mod_profiles/resources/measurementSourceList.py
+++ b/app/mod_profiles/resources/measurementSourceList.py
@@ -1,19 +1,19 @@
 from flask_restful import Resource, reqparse, marshal_with
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
-from .measurementSourceView import resource_fields
+from .measurementSourceView import MeasurementSourceView
 
 parser = reqparse.RequestParser()
 parser.add_argument('name', type=str, required=True)
 parser.add_argument('description', type=str)
 
 class MeasurementSourceList(Resource):
-    @marshal_with(resource_fields, envelope='resource')
+    @marshal_with(MeasurementSourceView.resource_fields, envelope='resource')
     def get(self):
         measurement_sources = MeasurementSource.query.all()
         return measurement_sources
 
-    @marshal_with(resource_fields, envelope='resource')
+    @marshal_with(MeasurementSourceView.resource_fields, envelope='resource')
     def post(self):
         args = parser.parse_args()
         new_measurement_source = MeasurementSource(args['name'],

--- a/app/mod_profiles/resources/measurementSourceView.py
+++ b/app/mod_profiles/resources/measurementSourceView.py
@@ -6,13 +6,13 @@ parser = reqparse.RequestParser()
 parser.add_argument('name', type=str, required=True)
 parser.add_argument('description', type=str)
 
-resource_fields = {
-    'id': fields.Integer,
-    'name': fields.String,
-    'description': fields.String,
-}
-
 class MeasurementSourceView(Resource):
+    resource_fields = {
+        'id': fields.Integer,
+        'name': fields.String,
+        'description': fields.String,
+    }
+
     @marshal_with(resource_fields, envelope='resource')
     def get(self, id):
         measurement_source = MeasurementSource.query.get_or_404(id)

--- a/app/mod_profiles/resources/measurementTypeList.py
+++ b/app/mod_profiles/resources/measurementTypeList.py
@@ -1,19 +1,19 @@
 from flask_restful import Resource, reqparse, marshal_with
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
-from .measurementTypeView import resource_fields
+from .measurementTypeView import MeasurementTypeView
 
 parser = reqparse.RequestParser()
 parser.add_argument('name', type=str, required=True)
 parser.add_argument('description', type=str)
 
 class MeasurementTypeList(Resource):
-    @marshal_with(resource_fields, envelope='resource')
+    @marshal_with(MeasurementTypeView.resource_fields, envelope='resource')
     def get(self):
         measurement_types = MeasurementType.query.all()
         return measurement_types
 
-    @marshal_with(resource_fields, envelope='resource')
+    @marshal_with(MeasurementTypeView.resource_fields, envelope='resource')
     def post(self):
         args = parser.parse_args()
         new_measurement_type = MeasurementType(args['name'],

--- a/app/mod_profiles/resources/measurementTypeView.py
+++ b/app/mod_profiles/resources/measurementTypeView.py
@@ -6,13 +6,13 @@ parser = reqparse.RequestParser()
 parser.add_argument('name', type=str, required=True)
 parser.add_argument('description', type=str)
 
-resource_fields = {
-    'id': fields.Integer,
-    'name': fields.String,
-    'description': fields.String,
-}
-
 class MeasurementTypeView(Resource):
+    resource_fields = {
+        'id': fields.Integer,
+        'name': fields.String,
+        'description': fields.String,
+    }
+
     @marshal_with(resource_fields, envelope='resource')
     def get(self, id):
         measurement_type = MeasurementType.query.get_or_404(id)

--- a/app/mod_profiles/resources/measurementUnitList.py
+++ b/app/mod_profiles/resources/measurementUnitList.py
@@ -1,7 +1,7 @@
 from flask_restful import Resource, reqparse, marshal_with
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
-from .measurementUnitView import resource_fields
+from .measurementUnitView import MeasurementUnitView
 
 parser = reqparse.RequestParser()
 parser.add_argument('name', type=str, required=True)
@@ -9,12 +9,12 @@ parser.add_argument('symbol', type=str, required=True)
 parser.add_argument('suffix', type=bool)
 
 class MeasurementUnitList(Resource):
-    @marshal_with(resource_fields, envelope='resource')
+    @marshal_with(MeasurementUnitView.resource_fields, envelope='resource')
     def get(self):
         measurement_units = MeasurementUnit.query.all()
         return measurement_units
 
-    @marshal_with(resource_fields, envelope='resource')
+    @marshal_with(MeasurementUnitView.resource_fields, envelope='resource')
     def post(self):
         args = parser.parse_args()
         new_measurement_unit = MeasurementUnit(args['name'],

--- a/app/mod_profiles/resources/measurementUnitView.py
+++ b/app/mod_profiles/resources/measurementUnitView.py
@@ -7,14 +7,14 @@ parser.add_argument('name', type=str, required=True)
 parser.add_argument('symbol', type=str, required=True)
 parser.add_argument('suffix', type=bool)
 
-resource_fields = {
-    'id': fields.Integer,
-    'name': fields.String,
-    'symbol': fields.String,
-    'suffix': fields.Boolean,
-}
-
 class MeasurementUnitView(Resource):
+    resource_fields = {
+        'id': fields.Integer,
+        'name': fields.String,
+        'symbol': fields.String,
+        'suffix': fields.Boolean,
+    }
+
     @marshal_with(resource_fields, envelope='resource')
     def get(self, id):
         measurement_unit = MeasurementUnit.query.get_or_404(id)

--- a/app/mod_profiles/resources/measurementView.py
+++ b/app/mod_profiles/resources/measurementView.py
@@ -1,11 +1,10 @@
 from flask_restful import Resource, reqparse, fields, marshal_with
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
-from .measurementSourceView import resource_fields as relation_measurement_source_fields
-from .measurementTypeView import resource_fields as relation_measurement_type_fields
-from .measurementUnitView import resource_fields as relation_measurement_unit_fields
-from .profileView import resource_fields as relation_profile_fields
-
+from .measurementSourceView import MeasurementSourceView
+from .measurementTypeView import MeasurementTypeView
+from .measurementUnitView import MeasurementUnitView
+from .profileView import ProfileView
 
 parser = reqparse.RequestParser()
 parser.add_argument('datetime', required=True)
@@ -15,17 +14,17 @@ parser.add_argument('measurement_source_id', type=int)
 parser.add_argument('measurement_type_id', type=int, required=True)
 parser.add_argument('measurement_unit_id', type=int, required=True)
 
-resource_fields = {
-    'id': fields.Integer,
-    'datetime': fields.DateTime(dt_format='iso8601'),
-    'value': fields.Float,
-    'profile': fields.Nested(relation_profile_fields),
-    'measurement_source': fields.Nested(relation_measurement_source_fields),
-    'measurement_type': fields.Nested(relation_measurement_type_fields),
-    'measurement_unit': fields.Nested(relation_measurement_unit_fields),
-}
-
 class MeasurementView(Resource):
+    resource_fields = {
+        'id': fields.Integer,
+        'datetime': fields.DateTime(dt_format='iso8601'),
+        'value': fields.Float,
+        'profile': fields.Nested(ProfileView.resource_fields),
+        'measurement_source': fields.Nested(MeasurementSourceView.resource_fields),
+        'measurement_type': fields.Nested(MeasurementTypeView.resource_fields),
+        'measurement_unit': fields.Nested(MeasurementUnitView.resource_fields),
+    }
+
     @marshal_with(resource_fields, envelope='resource')
     def get(self, id):
         measurement = Measurement.query.get_or_404(id)

--- a/app/mod_profiles/resources/profileLatestMeasurementList.py
+++ b/app/mod_profiles/resources/profileLatestMeasurementList.py
@@ -1,14 +1,14 @@
 from flask_restful import Resource, marshal_with
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
-from .measurementView import resource_fields as measurement_fields
-
-# Crea una copia de los campos del recurso 'Measurement'.
-resource_fields = measurement_fields.copy()
-# Quita el perfil asociado de los campos del recurso.
-del resource_fields['profile']
+from .measurementView import MeasurementView
 
 class ProfileLatestMeasurementList(Resource):
+    # Crea una copia de los campos del recurso 'MeasurementView'.
+    resource_fields = MeasurementView.resource_fields.copy()
+    # Quita el perfil asociado de los campos del recurso.
+    del resource_fields['profile']
+
     @marshal_with(resource_fields, envelope='resource')
     def get(self, profile_id):
         measurement_types = MeasurementType.query.all()

--- a/app/mod_profiles/resources/profileList.py
+++ b/app/mod_profiles/resources/profileList.py
@@ -1,7 +1,7 @@
 from flask_restful import Resource, reqparse, marshal_with
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
-from .profileView import resource_fields
+from .profileView import ProfileView
 
 parser = reqparse.RequestParser()
 parser.add_argument('last_name', type=str, required=True)
@@ -10,12 +10,12 @@ parser.add_argument('gender_id', type=int)
 parser.add_argument('birthday')
 
 class ProfileList(Resource):
-    @marshal_with(resource_fields, envelope='resource')
+    @marshal_with(ProfileView.resource_fields, envelope='resource')
     def get(self):
         profiles = Profile.query.all()
         return profiles
 
-    @marshal_with(resource_fields, envelope='resource')
+    @marshal_with(ProfileView.resource_fields, envelope='resource')
     def post(self):
         args = parser.parse_args()
         new_profile = Profile(args['last_name'],

--- a/app/mod_profiles/resources/profileMeasurementList.py
+++ b/app/mod_profiles/resources/profileMeasurementList.py
@@ -1,14 +1,14 @@
 from flask_restful import Resource, marshal_with
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
-from .measurementView import resource_fields as measurement_fields
-
-# Crea una copia de los campos del recurso 'Measurement'.
-resource_fields = measurement_fields.copy()
-# Quita el perfil asociado de los campos del recurso.
-del resource_fields['profile']
+from .measurementView import MeasurementView
 
 class ProfileMeasurementList(Resource):
+    # Crea una copia de los campos del recurso 'MeasurementView'.
+    resource_fields = MeasurementView.resource_fields.copy()
+    # Quita el perfil asociado de los campos del recurso.
+    del resource_fields['profile']
+
     @marshal_with(resource_fields, envelope='resource')
     def get(self, profile_id):
         profile = Profile.query.get_or_404(profile_id)

--- a/app/mod_profiles/resources/profileView.py
+++ b/app/mod_profiles/resources/profileView.py
@@ -1,7 +1,7 @@
 from flask_restful import Resource, reqparse, fields, marshal_with
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
-from .genderView import resource_fields as relation_gender_fields
+from .genderView import GenderView
 
 parser = reqparse.RequestParser()
 parser.add_argument('last_name', type=str, required=True)
@@ -9,15 +9,15 @@ parser.add_argument('first_name', type=str, required=True)
 parser.add_argument('gender_id', type=int)
 parser.add_argument('birthday')
 
-resource_fields = {
-    'id': fields.Integer,
-    'last_name': fields.String,
-    'first_name': fields.String,
-    'gender': fields.Nested(relation_gender_fields),
-    'birthday': fields.DateTime(dt_format='iso8601'),
-}
-
 class ProfileView(Resource):
+    resource_fields = {
+        'id': fields.Integer,
+        'last_name': fields.String,
+        'first_name': fields.String,
+        'gender': fields.Nested(GenderView.resource_fields),
+        'birthday': fields.DateTime(dt_format='iso8601'),
+    }
+
     @marshal_with(resource_fields, envelope='resource')
     def get(self, id):
         profile = Profile.query.get_or_404(id)


### PR DESCRIPTION
Se incorporaron los atributos ```resource_fields``` dentro de las clases relacionadas a recursos **View** de la API, para facilitar la asociación de modelos con **Swagger**. [1]

[1] https://github.com/rantav/flask-restful-swagger#using-marshal_with