### PR TITLE
Creación de versión inicial de documentación Swagger

### DIFF
--- a/app/mod_profiles/resources/genderFields.py
+++ b/app/mod_profiles/resources/genderFields.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+from flask_restful import fields
+from flask_restful_swagger import swagger
+
+@swagger.model
+class GenderFields:
+    resource_fields = {
+        'id': fields.Integer,
+        'name': fields.String,
+        'description': fields.String,
+    }

--- a/app/mod_profiles/resources/genderList.py
+++ b/app/mod_profiles/resources/genderList.py
@@ -1,19 +1,60 @@
+# -*- coding: utf-8 -*-
+
 from flask_restful import Resource, reqparse, marshal_with
+from flask_restful_swagger import swagger
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
-from .genderView import GenderView
+from .genderFields import GenderFields
 
 parser = reqparse.RequestParser()
 parser.add_argument('name', type=str, required=True)
 parser.add_argument('description', type=str)
 
 class GenderList(Resource):
-    @marshal_with(GenderView.resource_fields, envelope='resource')
+    @swagger.operation(
+        notes=u'Retorna todas las instancias existentes de género.'.encode('utf-8'),
+        responseClass='GenderFields',
+        nickname='genderList_get',
+        responseMessages=[
+            {
+              "code": 200,
+              "message": "Solicitud resuelta exitosamente."
+            }
+          ]
+        )
+    @marshal_with(GenderFields.resource_fields, envelope='resource')
     def get(self):
         genders = Gender.query.all()
         return genders
 
-    @marshal_with(GenderView.resource_fields, envelope='resource')
+    @swagger.operation(
+        notes=u'Crea una nueva instancia de género, y la retorna.'.encode('utf-8'),
+        responseClass='GenderFields',
+        nickname='genderList_post',
+        parameters=[
+            {
+              "name": "name",
+              "description": u'Nombre del género.'.encode('utf-8'),
+              "required": True,
+              "dataType": "string",
+              "paramType": "body"
+            },
+            {
+              "name": "description",
+              "description": u'Descripción del género.'.encode('utf-8'),
+              "required": False,
+              "dataType": "string",
+              "paramType": "body"
+            }
+          ],
+        responseMessages=[
+            {
+              "code": 201,
+              "message": "Objeto creado exitosamente."
+            }
+          ]
+        )
+    @marshal_with(GenderFields.resource_fields, envelope='resource')
     def post(self):
         args = parser.parse_args()
         new_gender = Gender(args['name'],

--- a/app/mod_profiles/resources/genderView.py
+++ b/app/mod_profiles/resources/genderView.py
@@ -1,24 +1,84 @@
-from flask_restful import Resource, reqparse, fields, marshal_with
+# -*- coding: utf-8 -*-
+
+from flask_restful import Resource, reqparse, marshal_with
+from flask_restful_swagger import swagger
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
+from .genderFields import GenderFields
 
 parser = reqparse.RequestParser()
 parser.add_argument('name', type=str, required=True)
 parser.add_argument('description', type=str)
 
 class GenderView(Resource):
-    resource_fields = {
-        'id': fields.Integer,
-        'name': fields.String,
-        'description': fields.String,
-    }
-
-    @marshal_with(resource_fields, envelope='resource')
+    @swagger.operation(
+        notes=u'Retorna una instancia específica de género.'.encode('utf-8'),
+        responseClass='GenderFields',
+        nickname='genderView_get',
+        parameters=[
+            {
+              "name": "id",
+              "description": u'Identificador único del género.'.encode('utf-8'),
+              "required": True,
+              "dataType": "int",
+              "paramType": "path"
+            }
+          ],
+        responseMessages=[
+            {
+              "code": 200,
+              "message": "Objeto encontrado."
+            },
+            {
+              "code": 404,
+              "message": "Objeto inexistente."
+            }
+          ]
+        )
+    @marshal_with(GenderFields.resource_fields, envelope='resource')
     def get(self, id):
         gender = Gender.query.get_or_404(id)
         return gender
 
-    @marshal_with(resource_fields, envelope='resource')
+    @swagger.operation(
+        notes=u'Actualiza una instancia específica de género, y la retorna.'.encode('utf-8'),
+        responseClass='GenderFields',
+        nickname='genderView_put',
+        parameters=[
+            {
+              "name": "id",
+              "description": u'Identificador único del género.'.encode('utf-8'),
+              "required": True,
+              "dataType": "int",
+              "paramType": "path"
+            },
+            {
+              "name": "name",
+              "description": u'Nombre del género.'.encode('utf-8'),
+              "required": True,
+              "dataType": "string",
+              "paramType": "body"
+            },
+            {
+              "name": "description",
+              "description": u'Descripción del género.'.encode('utf-8'),
+              "required": False,
+              "dataType": "string",
+              "paramType": "body"
+            }
+          ],
+        responseMessages=[
+            {
+              "code": 200,
+              "message": "Objeto actualizado exitosamente."
+            },
+            {
+              "code": 404,
+              "message": "Objeto inexistente."
+            }
+          ]
+        )
+    @marshal_with(GenderFields.resource_fields, envelope='resource')
     def put(self, id):
         gender = Gender.query.get_or_404(id)
         args = parser.parse_args()

--- a/app/mod_profiles/resources/measurementFields.py
+++ b/app/mod_profiles/resources/measurementFields.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+from flask_restful import fields
+from flask_restful_swagger import swagger
+from .profileFields import ProfileFields
+from .measurementSourceFields import MeasurementSourceFields
+from .measurementTypeFields import MeasurementTypeFields
+from .measurementUnitFields import MeasurementUnitFields
+
+@swagger.model
+@swagger.nested(profile='ProfileFields',
+                measurement_source='MeasurementSourceFields',
+                measurement_type='MeasurementTypeFields',
+                measurement_unit='MeasurementUnitFields')
+class MeasurementFields:
+    resource_fields = {
+        'id': fields.Integer,
+        'datetime': fields.DateTime(dt_format='iso8601'),
+        'value': fields.Float,
+        'profile': fields.Nested(ProfileFields.resource_fields),
+        'measurement_source': fields.Nested(MeasurementSourceFields.resource_fields),
+        'measurement_type': fields.Nested(MeasurementTypeFields.resource_fields),
+        'measurement_unit': fields.Nested(MeasurementUnitFields.resource_fields),
+    }

--- a/app/mod_profiles/resources/measurementList.py
+++ b/app/mod_profiles/resources/measurementList.py
@@ -1,7 +1,10 @@
+# -*- coding: utf-8 -*-
+
 from flask_restful import Resource, reqparse, marshal_with
+from flask_restful_swagger import swagger
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
-from .measurementView import MeasurementView
+from .measurementFields import MeasurementFields
 
 parser = reqparse.RequestParser()
 parser.add_argument('datetime', required=True)
@@ -12,12 +15,85 @@ parser.add_argument('measurement_type_id', type=int, required=True)
 parser.add_argument('measurement_unit_id', type=int, required=True)
 
 class MeasurementList(Resource):
-    @marshal_with(MeasurementView.resource_fields, envelope='resource')
+    @swagger.operation(
+        notes=u'Retorna todas las instancias existentes de medición.'.encode('utf-8'),
+        responseClass='MeasurementFields',
+        nickname='measurementList_get',
+        responseMessages=[
+            {
+              "code": 200,
+              "message": "Solicitud resuelta exitosamente."
+            }
+          ]
+        )
+    @marshal_with(MeasurementFields.resource_fields, envelope='resource')
     def get(self):
         measurements = Measurement.query.all()
         return measurements
 
-    @marshal_with(MeasurementView.resource_fields, envelope='resource')
+    @swagger.operation(
+        notes=u'Crea una nueva instancia de medición, y la retorna.'.encode('utf-8'),
+        responseClass='MeasurementFields',
+        nickname='measurementList_post',
+        parameters=[
+            {
+              "name": "id",
+              "description": u'Identificador único de la medición.'.encode('utf-8'),
+              "required": True,
+              "dataType": "int",
+              "paramType": "path"
+            },
+            {
+              "name": "datetime",
+              "description": u'Fecha y hora de la medición.'.encode('utf-8'),
+              "required": True,
+              "dataType": "datetime",
+              "paramType": "body"
+            },
+            {
+              "name": "value",
+              "description": u'Valor de la medición.'.encode('utf-8'),
+              "required": True,
+              "dataType": "float",
+              "paramType": "body"
+            },
+            {
+              "name": "profile_id",
+              "description": u'Identificador único del perfil asociado.'.encode('utf-8'),
+              "required": True,
+              "dataType": "int",
+              "paramType": "body"
+            },
+            {
+              "name": "measurement_source_id",
+              "description": u'Identificador único de la fuente de medición asociada.'.encode('utf-8'),
+              "required": False,
+              "dataType": "int",
+              "paramType": "body"
+            },
+            {
+              "name": "measurement_type_id",
+              "description": u'Identificador único del tipo de medición asociado.'.encode('utf-8'),
+              "required": True,
+              "dataType": "int",
+              "paramType": "body"
+            },
+            {
+              "name": "measurement_unit_id",
+              "description": u'Identificador único de la unidad de medición asociada.'.encode('utf-8'),
+              "required": True,
+              "dataType": "int",
+              "paramType": "body"
+            }
+          ],
+        responseMessages=[
+            {
+              "code": 201,
+              "message": "Objeto creado exitosamente."
+            }
+          ]
+        )
+    @marshal_with(MeasurementFields.resource_fields, envelope='resource')
     def post(self):
         args = parser.parse_args()
         new_measurement = Measurement(args['datetime'],

--- a/app/mod_profiles/resources/measurementSourceFields.py
+++ b/app/mod_profiles/resources/measurementSourceFields.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+from flask_restful import fields
+from flask_restful_swagger import swagger
+
+@swagger.model
+class MeasurementSourceFields:
+    resource_fields = {
+        'id': fields.Integer,
+        'name': fields.String,
+        'description': fields.String,
+    }

--- a/app/mod_profiles/resources/measurementSourceList.py
+++ b/app/mod_profiles/resources/measurementSourceList.py
@@ -1,19 +1,60 @@
+# -*- coding: utf-8 -*-
+
 from flask_restful import Resource, reqparse, marshal_with
+from flask_restful_swagger import swagger
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
-from .measurementSourceView import MeasurementSourceView
+from .measurementSourceFields import MeasurementSourceFields
 
 parser = reqparse.RequestParser()
 parser.add_argument('name', type=str, required=True)
 parser.add_argument('description', type=str)
 
 class MeasurementSourceList(Resource):
-    @marshal_with(MeasurementSourceView.resource_fields, envelope='resource')
+    @swagger.operation(
+        notes=u'Retorna todas las instancias existentes de fuente de medición.'.encode('utf-8'),
+        responseClass='MeasurementSourceFields',
+        nickname='measurementSourceList_get',
+        responseMessages=[
+            {
+              "code": 200,
+              "message": "Solicitud resuelta exitosamente."
+            }
+          ]
+        )
+    @marshal_with(MeasurementSourceFields.resource_fields, envelope='resource')
     def get(self):
         measurement_sources = MeasurementSource.query.all()
         return measurement_sources
 
-    @marshal_with(MeasurementSourceView.resource_fields, envelope='resource')
+    @swagger.operation(
+        notes=u'Crea una nueva instancia de fuente de medición, y la retorna.'.encode('utf-8'),
+        responseClass='MeasurementSourceFields',
+        nickname='measurementSourceList_post',
+        parameters=[
+            {
+              "name": "name",
+              "description": u'Nombre de la fuente de medición.'.encode('utf-8'),
+              "required": True,
+              "dataType": "string",
+              "paramType": "body"
+            },
+            {
+              "name": "description",
+              "description": u'Descripción de la fuente de medición.'.encode('utf-8'),
+              "required": False,
+              "dataType": "string",
+              "paramType": "body"
+            }
+          ],
+        responseMessages=[
+            {
+              "code": 201,
+              "message": "Objeto creado exitosamente."
+            }
+          ]
+        )
+    @marshal_with(MeasurementSourceFields.resource_fields, envelope='resource')
     def post(self):
         args = parser.parse_args()
         new_measurement_source = MeasurementSource(args['name'],

--- a/app/mod_profiles/resources/measurementSourceView.py
+++ b/app/mod_profiles/resources/measurementSourceView.py
@@ -1,24 +1,84 @@
-from flask_restful import Resource, reqparse, fields, marshal_with
+# -*- coding: utf-8 -*-
+
+from flask_restful import Resource, reqparse, marshal_with
+from flask_restful_swagger import swagger
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
+from .measurementSourceFields import MeasurementSourceFields
 
 parser = reqparse.RequestParser()
 parser.add_argument('name', type=str, required=True)
 parser.add_argument('description', type=str)
 
 class MeasurementSourceView(Resource):
-    resource_fields = {
-        'id': fields.Integer,
-        'name': fields.String,
-        'description': fields.String,
-    }
-
-    @marshal_with(resource_fields, envelope='resource')
+    @swagger.operation(
+        notes=u'Retorna una instancia específica de fuente de medición.'.encode('utf-8'),
+        responseClass='MeasurementSourceFields',
+        nickname='measurementSourceView_get',
+        parameters=[
+            {
+              "name": "id",
+              "description": u'Identificador único de la fuente de medición.'.encode('utf-8'),
+              "required": True,
+              "dataType": "int",
+              "paramType": "path"
+            }
+          ],
+        responseMessages=[
+            {
+              "code": 200,
+              "message": "Objeto encontrado."
+            },
+            {
+              "code": 404,
+              "message": "Objeto inexistente."
+            }
+          ]
+        )
+    @marshal_with(MeasurementSourceFields.resource_fields, envelope='resource')
     def get(self, id):
         measurement_source = MeasurementSource.query.get_or_404(id)
         return measurement_source
 
-    @marshal_with(resource_fields, envelope='resource')
+    @swagger.operation(
+        notes=u'Actualiza una instancia específica de fuente de medición, y la retorna.'.encode('utf-8'),
+        responseClass='MeasurementSourceFields',
+        nickname='measurementSourceView_put',
+        parameters=[
+            {
+              "name": "id",
+              "description": u'Identificador único de la fuente de medición.'.encode('utf-8'),
+              "required": True,
+              "dataType": "int",
+              "paramType": "path"
+            },
+            {
+              "name": "name",
+              "description": u'Nombre de la fuente de medición.'.encode('utf-8'),
+              "required": True,
+              "dataType": "string",
+              "paramType": "body"
+            },
+            {
+              "name": "description",
+              "description": u'Descripción de la fuente de medición.'.encode('utf-8'),
+              "required": False,
+              "dataType": "string",
+              "paramType": "body"
+            }
+          ],
+        responseMessages=[
+            {
+              "code": 200,
+              "message": "Objeto actualizado exitosamente."
+            },
+            {
+              "code": 404,
+              "message": "Objeto inexistente."
+            }
+          ]
+        )
+    @marshal_with(MeasurementSourceFields.resource_fields, envelope='resource')
     def put(self, id):
         measurement_source = MeasurementSource.query.get_or_404(id)
         args = parser.parse_args()

--- a/app/mod_profiles/resources/measurementTypeFields.py
+++ b/app/mod_profiles/resources/measurementTypeFields.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+from flask_restful import fields
+from flask_restful_swagger import swagger
+
+@swagger.model
+class MeasurementTypeFields:
+    resource_fields = {
+        'id': fields.Integer,
+        'name': fields.String,
+        'description': fields.String,
+    }

--- a/app/mod_profiles/resources/measurementTypeList.py
+++ b/app/mod_profiles/resources/measurementTypeList.py
@@ -1,19 +1,60 @@
+# -*- coding: utf-8 -*-
+
 from flask_restful import Resource, reqparse, marshal_with
+from flask_restful_swagger import swagger
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
-from .measurementTypeView import MeasurementTypeView
+from .measurementTypeFields import MeasurementTypeFields
 
 parser = reqparse.RequestParser()
 parser.add_argument('name', type=str, required=True)
 parser.add_argument('description', type=str)
 
 class MeasurementTypeList(Resource):
-    @marshal_with(MeasurementTypeView.resource_fields, envelope='resource')
+    @swagger.operation(
+        notes=u'Retorna todas las instancias existentes de tipo de medición.'.encode('utf-8'),
+        responseClass='MeasurementTypeFields',
+        nickname='measurementTypeList_get',
+        responseMessages=[
+            {
+              "code": 200,
+              "message": "Solicitud resuelta exitosamente."
+            }
+          ]
+        )
+    @marshal_with(MeasurementTypeFields.resource_fields, envelope='resource')
     def get(self):
         measurement_types = MeasurementType.query.all()
         return measurement_types
 
-    @marshal_with(MeasurementTypeView.resource_fields, envelope='resource')
+    @swagger.operation(
+        notes=u'Crea una nueva instancia de tipo de medición, y la retorna.'.encode('utf-8'),
+        responseClass='MeasurementTypeFields',
+        nickname='measurementTypeList_post',
+        parameters=[
+            {
+              "name": "name",
+              "description": u'Nombre del tipo de medición.'.encode('utf-8'),
+              "required": True,
+              "dataType": "string",
+              "paramType": "body"
+            },
+            {
+              "name": "description",
+              "description": u'Descripción del tipo de medición.'.encode('utf-8'),
+              "required": False,
+              "dataType": "string",
+              "paramType": "body"
+            }
+          ],
+        responseMessages=[
+            {
+              "code": 201,
+              "message": "Objeto creado exitosamente."
+            }
+          ]
+        )
+    @marshal_with(MeasurementTypeFields.resource_fields, envelope='resource')
     def post(self):
         args = parser.parse_args()
         new_measurement_type = MeasurementType(args['name'],

--- a/app/mod_profiles/resources/measurementTypeView.py
+++ b/app/mod_profiles/resources/measurementTypeView.py
@@ -1,24 +1,84 @@
-from flask_restful import Resource, reqparse, fields, marshal_with
+# -*- coding: utf-8 -*-
+
+from flask_restful import Resource, reqparse, marshal_with
+from flask_restful_swagger import swagger
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
+from .measurementTypeFields import MeasurementTypeFields
 
 parser = reqparse.RequestParser()
 parser.add_argument('name', type=str, required=True)
 parser.add_argument('description', type=str)
 
 class MeasurementTypeView(Resource):
-    resource_fields = {
-        'id': fields.Integer,
-        'name': fields.String,
-        'description': fields.String,
-    }
-
-    @marshal_with(resource_fields, envelope='resource')
+    @swagger.operation(
+        notes=u'Retorna una instancia específica de tipo de medición.'.encode('utf-8'),
+        responseClass='MeasurementTypeFields',
+        nickname='measurementTypeView_get',
+        parameters=[
+            {
+              "name": "id",
+              "description": u'Identificador único del tipo de medición.'.encode('utf-8'),
+              "required": True,
+              "dataType": "int",
+              "paramType": "path"
+            }
+          ],
+        responseMessages=[
+            {
+              "code": 200,
+              "message": "Objeto encontrado."
+            },
+            {
+              "code": 404,
+              "message": "Objeto inexistente."
+            }
+          ]
+        )
+    @marshal_with(MeasurementTypeFields.resource_fields, envelope='resource')
     def get(self, id):
         measurement_type = MeasurementType.query.get_or_404(id)
         return measurement_type
 
-    @marshal_with(resource_fields, envelope='resource')
+    @swagger.operation(
+        notes=u'Actualiza una instancia específica de tipo de medición, y la retorna.'.encode('utf-8'),
+        responseClass='MeasurementTypeFields',
+        nickname='measurementTypeView_put',
+        parameters=[
+            {
+              "name": "id",
+              "description": u'Identificador único del tipo de medición.'.encode('utf-8'),
+              "required": True,
+              "dataType": "int",
+              "paramType": "path"
+            },
+            {
+              "name": "name",
+              "description": u'Nombre del tipo de medición.'.encode('utf-8'),
+              "required": True,
+              "dataType": "string",
+              "paramType": "body"
+            },
+            {
+              "name": "description",
+              "description": u'Descripción del tipo de medición.'.encode('utf-8'),
+              "required": False,
+              "dataType": "string",
+              "paramType": "body"
+            }
+          ],
+        responseMessages=[
+            {
+              "code": 200,
+              "message": "Objeto actualizado exitosamente."
+            },
+            {
+              "code": 404,
+              "message": "Objeto inexistente."
+            }
+          ]
+        )
+    @marshal_with(MeasurementTypeFields.resource_fields, envelope='resource')
     def put(self, id):
         measurement_type = MeasurementType.query.get_or_404(id)
         args = parser.parse_args()

--- a/app/mod_profiles/resources/measurementUnitFields.py
+++ b/app/mod_profiles/resources/measurementUnitFields.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+from flask_restful import fields
+from flask_restful_swagger import swagger
+
+@swagger.model
+class MeasurementUnitFields:
+    resource_fields = {
+        'id': fields.Integer,
+        'name': fields.String,
+        'symbol': fields.String,
+        'suffix': fields.Boolean,
+    }

--- a/app/mod_profiles/resources/measurementUnitList.py
+++ b/app/mod_profiles/resources/measurementUnitList.py
@@ -1,7 +1,10 @@
+# -*- coding: utf-8 -*-
+
 from flask_restful import Resource, reqparse, marshal_with
+from flask_restful_swagger import swagger
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
-from .measurementUnitView import MeasurementUnitView
+from .measurementUnitFields import MeasurementUnitFields
 
 parser = reqparse.RequestParser()
 parser.add_argument('name', type=str, required=True)
@@ -9,12 +12,66 @@ parser.add_argument('symbol', type=str, required=True)
 parser.add_argument('suffix', type=bool)
 
 class MeasurementUnitList(Resource):
-    @marshal_with(MeasurementUnitView.resource_fields, envelope='resource')
+    @swagger.operation(
+        notes=u'Retorna todas las instancias existentes de unidad de medición.'.encode('utf-8'),
+        responseClass='MeasurementUnitFields',
+        nickname='measurementUnitList_get',
+        responseMessages=[
+            {
+              "code": 200,
+              "message": "Solicitud resuelta exitosamente."
+            }
+          ]
+        )
+    @marshal_with(MeasurementUnitFields.resource_fields, envelope='resource')
     def get(self):
         measurement_units = MeasurementUnit.query.all()
         return measurement_units
 
-    @marshal_with(MeasurementUnitView.resource_fields, envelope='resource')
+    @swagger.operation(
+        notes=u'Crea una nueva instancia de unidad de medición, y la retorna.'.encode('utf-8'),
+        responseClass='MeasurementUnitFields',
+        nickname='measurementUnitList_post',
+        parameters=[
+            {
+              "name": "id",
+              "description": u'Identificador único de la unidad de medición.'.encode('utf-8'),
+              "required": True,
+              "dataType": "int",
+              "paramType": "path"
+            },
+            {
+              "name": "name",
+              "description": u'Nombre de la unidad de medición.'.encode('utf-8'),
+              "required": True,
+              "dataType": "string",
+              "paramType": "body"
+            },
+            {
+              "name": "symbol",
+              "description": u'Símbolo de la unidad de medición.'.encode('utf-8'),
+              "required": True,
+              "dataType": "string",
+              "paramType": "body"
+            },
+            {
+              "name": "suffix",
+              "description": (u'Variable booleana que indica si el símbolo de '
+                              'la unidad de medición es un sufijo (verdadero) '
+                              'o un prefijo (falso) del valor de la medición.').encode('utf-8'),
+              "required": False,
+              "dataType": "boolean",
+              "paramType": "body"
+            }
+          ],
+        responseMessages=[
+            {
+              "code": 201,
+              "message": "Objeto creado exitosamente."
+            }
+          ]
+        )
+    @marshal_with(MeasurementUnitFields.resource_fields, envelope='resource')
     def post(self):
         args = parser.parse_args()
         new_measurement_unit = MeasurementUnit(args['name'],

--- a/app/mod_profiles/resources/measurementUnitView.py
+++ b/app/mod_profiles/resources/measurementUnitView.py
@@ -1,6 +1,10 @@
-from flask_restful import Resource, reqparse, fields, marshal_with
+# -*- coding: utf-8 -*-
+
+from flask_restful import Resource, reqparse, marshal_with
+from flask_restful_swagger import swagger
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
+from .measurementUnitFields import MeasurementUnitFields
 
 parser = reqparse.RequestParser()
 parser.add_argument('name', type=str, required=True)
@@ -8,19 +12,83 @@ parser.add_argument('symbol', type=str, required=True)
 parser.add_argument('suffix', type=bool)
 
 class MeasurementUnitView(Resource):
-    resource_fields = {
-        'id': fields.Integer,
-        'name': fields.String,
-        'symbol': fields.String,
-        'suffix': fields.Boolean,
-    }
-
-    @marshal_with(resource_fields, envelope='resource')
+    @swagger.operation(
+        notes=u'Retorna una instancia específica de unidad de medición.'.encode('utf-8'),
+        responseClass='MeasurementUnitFields',
+        nickname='measurementUnitView_get',
+        parameters=[
+            {
+              "name": "id",
+              "description": u'Identificador único de la unidad de medición.'.encode('utf-8'),
+              "required": True,
+              "dataType": "int",
+              "paramType": "path"
+            }
+          ],
+        responseMessages=[
+            {
+              "code": 200,
+              "message": "Objeto encontrado."
+            },
+            {
+              "code": 404,
+              "message": "Objeto inexistente."
+            }
+          ]
+        )
+    @marshal_with(MeasurementUnitFields.resource_fields, envelope='resource')
     def get(self, id):
         measurement_unit = MeasurementUnit.query.get_or_404(id)
         return measurement_unit
 
-    @marshal_with(resource_fields, envelope='resource')
+    @swagger.operation(
+        notes=u'Actualiza una instancia específica de unidad de medición, y la retorna.'.encode('utf-8'),
+        responseClass='MeasurementUnitFields',
+        nickname='measurementUnitView_put',
+        parameters=[
+            {
+              "name": "id",
+              "description": u'Identificador único de la unidad de medición.'.encode('utf-8'),
+              "required": True,
+              "dataType": "int",
+              "paramType": "path"
+            },
+            {
+              "name": "name",
+              "description": u'Nombre de la unidad de medición.'.encode('utf-8'),
+              "required": True,
+              "dataType": "string",
+              "paramType": "body"
+            },
+            {
+              "name": "symbol",
+              "description": u'Símbolo de la unidad de medición.'.encode('utf-8'),
+              "required": True,
+              "dataType": "string",
+              "paramType": "body"
+            },
+            {
+              "name": "suffix",
+              "description": (u'Variable booleana que indica si el símbolo de '
+                              'la unidad de medición es un sufijo (verdadero) '
+                              'o un prefijo (falso) del valor de la medición.').encode('utf-8'),
+              "required": False,
+              "dataType": "boolean",
+              "paramType": "body"
+            }
+          ],
+        responseMessages=[
+            {
+              "code": 200,
+              "message": "Objeto actualizado exitosamente."
+            },
+            {
+              "code": 404,
+              "message": "Objeto inexistente."
+            }
+          ]
+        )
+    @marshal_with(MeasurementUnitFields.resource_fields, envelope='resource')
     def put(self, id):
         measurement_unit = MeasurementUnit.query.get_or_404(id)
         args = parser.parse_args()

--- a/app/mod_profiles/resources/measurementView.py
+++ b/app/mod_profiles/resources/measurementView.py
@@ -1,10 +1,10 @@
-from flask_restful import Resource, reqparse, fields, marshal_with
+# -*- coding: utf-8 -*-
+
+from flask_restful import Resource, reqparse, marshal_with
+from flask_restful_swagger import swagger
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
-from .measurementSourceView import MeasurementSourceView
-from .measurementTypeView import MeasurementTypeView
-from .measurementUnitView import MeasurementUnitView
-from .profileView import ProfileView
+from .measurementFields import MeasurementFields
 
 parser = reqparse.RequestParser()
 parser.add_argument('datetime', required=True)
@@ -15,22 +15,102 @@ parser.add_argument('measurement_type_id', type=int, required=True)
 parser.add_argument('measurement_unit_id', type=int, required=True)
 
 class MeasurementView(Resource):
-    resource_fields = {
-        'id': fields.Integer,
-        'datetime': fields.DateTime(dt_format='iso8601'),
-        'value': fields.Float,
-        'profile': fields.Nested(ProfileView.resource_fields),
-        'measurement_source': fields.Nested(MeasurementSourceView.resource_fields),
-        'measurement_type': fields.Nested(MeasurementTypeView.resource_fields),
-        'measurement_unit': fields.Nested(MeasurementUnitView.resource_fields),
-    }
-
-    @marshal_with(resource_fields, envelope='resource')
+    @swagger.operation(
+        notes=u'Retorna una instancia específica de medición.'.encode('utf-8'),
+        responseClass='MeasurementFields',
+        nickname='measurementView_get',
+        parameters=[
+            {
+              "name": "id",
+              "description": u'Identificador único de la medición.'.encode('utf-8'),
+              "required": True,
+              "dataType": "int",
+              "paramType": "path"
+            }
+          ],
+        responseMessages=[
+            {
+              "code": 200,
+              "message": "Objeto encontrado."
+            },
+            {
+              "code": 404,
+              "message": "Objeto inexistente."
+            }
+          ]
+        )
+    @marshal_with(MeasurementFields.resource_fields, envelope='resource')
     def get(self, id):
         measurement = Measurement.query.get_or_404(id)
         return measurement
 
-    @marshal_with(resource_fields, envelope='resource')
+    @swagger.operation(
+        notes=u'Actualiza una instancia específica de medición, y la retorna.'.encode('utf-8'),
+        responseClass='MeasurementFields',
+        nickname='measurementView_put',
+        parameters=[
+            {
+              "name": "id",
+              "description": u'Identificador único de la medición.'.encode('utf-8'),
+              "required": True,
+              "dataType": "int",
+              "paramType": "path"
+            },
+            {
+              "name": "datetime",
+              "description": u'Fecha y hora de la medición.'.encode('utf-8'),
+              "required": True,
+              "dataType": "datetime",
+              "paramType": "body"
+            },
+            {
+              "name": "value",
+              "description": u'Valor de la medición.'.encode('utf-8'),
+              "required": True,
+              "dataType": "float",
+              "paramType": "body"
+            },
+            {
+              "name": "profile_id",
+              "description": u'Identificador único del perfil asociado.'.encode('utf-8'),
+              "required": True,
+              "dataType": "int",
+              "paramType": "body"
+            },
+            {
+              "name": "measurement_source_id",
+              "description": u'Identificador único de la fuente de medición asociada.'.encode('utf-8'),
+              "required": False,
+              "dataType": "int",
+              "paramType": "body"
+            },
+            {
+              "name": "measurement_type_id",
+              "description": u'Identificador único del tipo de medición asociado.'.encode('utf-8'),
+              "required": True,
+              "dataType": "int",
+              "paramType": "body"
+            },
+            {
+              "name": "measurement_unit_id",
+              "description": u'Identificador único de la unidad de medición asociada.'.encode('utf-8'),
+              "required": True,
+              "dataType": "int",
+              "paramType": "body"
+            }
+          ],
+        responseMessages=[
+            {
+              "code": 200,
+              "message": "Objeto actualizado exitosamente."
+            },
+            {
+              "code": 404,
+              "message": "Objeto inexistente."
+            }
+          ]
+        )
+    @marshal_with(MeasurementFields.resource_fields, envelope='resource')
     def put(self, id):
         measurement = Measurement.query.get_or_404(id)
         args = parser.parse_args()

--- a/app/mod_profiles/resources/profileFields.py
+++ b/app/mod_profiles/resources/profileFields.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+from flask_restful import fields
+from flask_restful_swagger import swagger
+from .genderFields import GenderFields
+
+@swagger.model
+@swagger.nested(gender='GenderFields')
+class ProfileFields:
+    resource_fields = {
+        'id': fields.Integer,
+        'last_name': fields.String,
+        'first_name': fields.String,
+        'gender': fields.Nested(GenderFields.resource_fields),
+        'birthday': fields.DateTime(dt_format='iso8601'),
+    }

--- a/app/mod_profiles/resources/profileLatestMeasurementList.py
+++ b/app/mod_profiles/resources/profileLatestMeasurementList.py
@@ -1,14 +1,42 @@
+# -*- coding: utf-8 -*-
+
 from flask_restful import Resource, marshal_with
+from flask_restful_swagger import swagger
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
-from .measurementView import MeasurementView
+from .measurementFields import MeasurementFields
 
 class ProfileLatestMeasurementList(Resource):
     # Crea una copia de los campos del recurso 'MeasurementView'.
-    resource_fields = MeasurementView.resource_fields.copy()
+    resource_fields = MeasurementFields.resource_fields.copy()
     # Quita el perfil asociado de los campos del recurso.
     del resource_fields['profile']
 
+    @swagger.operation(
+        notes= (u'Retorna la última instancia de medición de cada tipo de '
+                'medición, asociadas a un perfil específico.').encode('utf-8'),
+        responseClass='MeasurementFields',
+        nickname='profileLatestMeasurementList_get',
+        parameters=[
+            {
+              "name": "profile_id",
+              "description": u'Identificador único del perfil.'.encode('utf-8'),
+              "required": True,
+              "dataType": "int",
+              "paramType": "path"
+            }
+          ],
+        responseMessages=[
+            {
+              "code": 200,
+              "message": "Objeto encontrado."
+            },
+            {
+              "code": 404,
+              "message": "Objeto inexistente."
+            }
+          ]
+        )
     @marshal_with(resource_fields, envelope='resource')
     def get(self, profile_id):
         measurement_types = MeasurementType.query.all()

--- a/app/mod_profiles/resources/profileList.py
+++ b/app/mod_profiles/resources/profileList.py
@@ -1,7 +1,10 @@
+# -*- coding: utf-8 -*-
+
 from flask_restful import Resource, reqparse, marshal_with
+from flask_restful_swagger import swagger
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
-from .profileView import ProfileView
+from .profileFields import ProfileFields
 
 parser = reqparse.RequestParser()
 parser.add_argument('last_name', type=str, required=True)
@@ -10,12 +13,71 @@ parser.add_argument('gender_id', type=int)
 parser.add_argument('birthday')
 
 class ProfileList(Resource):
-    @marshal_with(ProfileView.resource_fields, envelope='resource')
+    @swagger.operation(
+        notes=u'Retorna todas las instancias existentes de perfil.'.encode('utf-8'),
+        responseClass='ProfileFields',
+        nickname='profileList_get',
+        responseMessages=[
+            {
+              "code": 200,
+              "message": "Solicitud resuelta exitosamente."
+            }
+          ]
+        )
+    @marshal_with(ProfileFields.resource_fields, envelope='resource')
     def get(self):
         profiles = Profile.query.all()
         return profiles
 
-    @marshal_with(ProfileView.resource_fields, envelope='resource')
+    @swagger.operation(
+        notes=u'Crea una nueva instancia de perfil, y la retorna.'.encode('utf-8'),
+        responseClass='ProfileFields',
+        nickname='profileList_post',
+        parameters=[
+            {
+              "name": "id",
+              "description": u'Identificador único del perfil.'.encode('utf-8'),
+              "required": True,
+              "dataType": "int",
+              "paramType": "path"
+            },
+            {
+              "name": "last_name",
+              "description": u'Apellido de la persona.'.encode('utf-8'),
+              "required": True,
+              "dataType": "string",
+              "paramType": "body"
+            },
+            {
+              "name": "first_name",
+              "description": u'Nombre de la persona.'.encode('utf-8'),
+              "required": True,
+              "dataType": "string",
+              "paramType": "body"
+            },
+            {
+              "name": "birthday",
+              "description": u'Fecha de nacimiento de la persona, en formato ISO 8601.'.encode('utf-8'),
+              "required": False,
+              "dataType": "datetime",
+              "paramType": "body"
+            },
+            {
+              "name": "gender_id",
+              "description": u'Identificador único del género asociado.'.encode('utf-8'),
+              "required": False,
+              "dataType": "int",
+              "paramType": "body"
+            }
+          ],
+        responseMessages=[
+            {
+              "code": 201,
+              "message": "Objeto creado exitosamente."
+            }
+          ]
+        )
+    @marshal_with(ProfileFields.resource_fields, envelope='resource')
     def post(self):
         args = parser.parse_args()
         new_profile = Profile(args['last_name'],

--- a/app/mod_profiles/resources/profileMeasurementList.py
+++ b/app/mod_profiles/resources/profileMeasurementList.py
@@ -1,14 +1,42 @@
+# -*- coding: utf-8 -*-
+
 from flask_restful import Resource, marshal_with
+from flask_restful_swagger import swagger
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
-from .measurementView import MeasurementView
+from .measurementFields import MeasurementFields
 
 class ProfileMeasurementList(Resource):
     # Crea una copia de los campos del recurso 'MeasurementView'.
-    resource_fields = MeasurementView.resource_fields.copy()
+    resource_fields = MeasurementFields.resource_fields.copy()
     # Quita el perfil asociado de los campos del recurso.
     del resource_fields['profile']
 
+    @swagger.operation(
+        notes= (u'Retorna todas las instancias existentes de medición, '
+                'asociadas a un perfil específico.').encode('utf-8'),
+        responseClass='MeasurementFields',
+        nickname='profileMeasurementList_get',
+        parameters=[
+            {
+              "name": "profile_id",
+              "description": u'Identificador único del perfil.'.encode('utf-8'),
+              "required": True,
+              "dataType": "int",
+              "paramType": "path"
+            }
+          ],
+        responseMessages=[
+            {
+              "code": 200,
+              "message": "Objeto encontrado."
+            },
+            {
+              "code": 404,
+              "message": "Objeto inexistente."
+            }
+          ]
+        )
     @marshal_with(resource_fields, envelope='resource')
     def get(self, profile_id):
         profile = Profile.query.get_or_404(profile_id)

--- a/app/mod_profiles/resources/profileView.py
+++ b/app/mod_profiles/resources/profileView.py
@@ -1,7 +1,10 @@
-from flask_restful import Resource, reqparse, fields, marshal_with
+# -*- coding: utf-8 -*-
+
+from flask_restful import Resource, reqparse, marshal_with
+from flask_restful_swagger import swagger
 from app.mod_shared.models import db
 from app.mod_profiles.models import *
-from .genderView import GenderView
+from .profileFields import ProfileFields
 
 parser = reqparse.RequestParser()
 parser.add_argument('last_name', type=str, required=True)
@@ -10,20 +13,88 @@ parser.add_argument('gender_id', type=int)
 parser.add_argument('birthday')
 
 class ProfileView(Resource):
-    resource_fields = {
-        'id': fields.Integer,
-        'last_name': fields.String,
-        'first_name': fields.String,
-        'gender': fields.Nested(GenderView.resource_fields),
-        'birthday': fields.DateTime(dt_format='iso8601'),
-    }
-
-    @marshal_with(resource_fields, envelope='resource')
+    @swagger.operation(
+        notes=u'Retorna una instancia específica de perfil.'.encode('utf-8'),
+        responseClass='ProfileFields',
+        nickname='profileView_get',
+        parameters=[
+            {
+              "name": "id",
+              "description": u'Identificador único del perfil.'.encode('utf-8'),
+              "required": True,
+              "dataType": "int",
+              "paramType": "path"
+            }
+          ],
+        responseMessages=[
+            {
+              "code": 200,
+              "message": "Objeto encontrado."
+            },
+            {
+              "code": 404,
+              "message": "Objeto inexistente."
+            }
+          ]
+        )
+    @marshal_with(ProfileFields.resource_fields, envelope='resource')
     def get(self, id):
         profile = Profile.query.get_or_404(id)
         return profile
 
-    @marshal_with(resource_fields, envelope='resource')
+    @swagger.operation(
+        notes=u'Actualiza una instancia específica de perfil, y la retorna.'.encode('utf-8'),
+        responseClass='ProfileFields',
+        nickname='profileView_put',
+        parameters=[
+            {
+              "name": "id",
+              "description": u'Identificador único del perfil.'.encode('utf-8'),
+              "required": True,
+              "dataType": "int",
+              "paramType": "path"
+            },
+            {
+              "name": "last_name",
+              "description": u'Apellido de la persona.'.encode('utf-8'),
+              "required": True,
+              "dataType": "string",
+              "paramType": "body"
+            },
+            {
+              "name": "first_name",
+              "description": u'Nombre de la persona.'.encode('utf-8'),
+              "required": True,
+              "dataType": "string",
+              "paramType": "body"
+            },
+            {
+              "name": "birthday",
+              "description": u'Fecha de nacimiento de la persona, en formato ISO 8601.'.encode('utf-8'),
+              "required": False,
+              "dataType": "datetime",
+              "paramType": "body"
+            },
+            {
+              "name": "gender_id",
+              "description": u'Identificador único del género asociado.'.encode('utf-8'),
+              "required": False,
+              "dataType": "int",
+              "paramType": "body"
+            }
+          ],
+        responseMessages=[
+            {
+              "code": 200,
+              "message": "Objeto actualizado exitosamente."
+            },
+            {
+              "code": 404,
+              "message": "Objeto inexistente."
+            }
+          ]
+        )
+    @marshal_with(ProfileFields.resource_fields, envelope='resource')
     def put(self, id):
         profile = Profile.query.get_or_404(id)
         args = parser.parse_args()


### PR DESCRIPTION
Se crearon operaciones **Swagger** para todos los recursos existentes hasta el momento. Debido al uso de campos ```fields.Nested```, los atributos ```resource_files``` se trasladaron a nuevas clases **Field** y se actualizaron las referencias a los mismos.